### PR TITLE
Create mod.conf

### DIFF
--- a/mod.conf
+++ b/mod.conf
@@ -1,0 +1,3 @@
+name =  what_is_this_owo-minetest
+description = show pointed noes ...
+depends =


### PR DESCRIPTION
get warning as missing like this.

but use:
name = what_is_this_owo
description  = A mod that says at the top of your screen what you're looking at.

as this are your worlds written

just a friendly hint.